### PR TITLE
feat: RSA key configuration and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This module **does not** create a reader role that can be used to view the data.
 | Name | Description |
 |------|-------------|
 | <a name="output_gcs_storage_integration"></a> [gcs\_storage\_integration](#output\_gcs\_storage\_integration) | The name of the GCS storage integration that can be used in the Fullstory app when configuring the Snowflake integration. |
-| <a name="output_password"></a> [password](#output\_password) | The Fullstory password that can be used in the Fullstory app when configuring the Snowflake integration. Will be empty if `disable_password` is true. |
+| <a name="output_password"></a> [password](#output\_password) | The password for the configured user that can be used in the Fullstory app when configuring the Snowflake integration. Will be empty if `disable_password` is true. |
 | <a name="output_role"></a> [role](#output\_role) | The Fullstory role that can be used in the Fullstory app when configuring the Snowflake integration. |
 | <a name="output_username"></a> [username](#output\_username) | The Fullstory username that can be used in the Fullstory app when configuring the Snowflake integration. |
 

--- a/README.md
+++ b/README.md
@@ -14,17 +14,23 @@ This module **does not** create a reader role that can be used to view the data.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
-| <a name="requirement_snowflake"></a> [snowflake](#requirement\_snowflake) | >= 0.83.1 |
+| <a name="requirement_snowflake"></a> [snowflake](#requirement\_snowflake) | ~> 0.83.1 |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_database_name"></a> [database\_name](#input\_database\_name) | The name of the Snowflake database to use | `string` | n/a | yes |
-| <a name="input_fullstory_cidr_ipv4"></a> [fullstory\_cidr\_ipv4](#input\_fullstory\_cidr\_ipv4) | The CIDR block that Fullstory will use to connect to the Redshift cluster. | `string` | `""` | no |
+| <a name="input_disable_password"></a> [disable\_password](#input\_disable\_password) | Whether to disable the password for the Snowflake user. If true, the user will only be able to authenticate using the RSA public key. | `bool` | `false` | no |
+| <a name="input_fullstory_cidr_ipv4"></a> [fullstory\_cidr\_ipv4](#input\_fullstory\_cidr\_ipv4) | The CIDR block that Fullstory will use to connect to Snowflake. | `string` | `""` | no |
 | <a name="input_fullstory_data_center"></a> [fullstory\_data\_center](#input\_fullstory\_data\_center) | The data center where your Fullstory account is hosted. Either 'NA1' or 'EU1'. See https://help.fullstory.com/hc/en-us/articles/8901113940375-Fullstory-Data-Residency for more information. | `string` | `"NA1"` | no |
 | <a name="input_fullstory_storage_allowed_locations"></a> [fullstory\_storage\_allowed\_locations](#input\_fullstory\_storage\_allowed\_locations) | The list of allowed locations for the storage provider. This is an advanced option and should only be changed if instructed by Fullstory. Ex. <cloud>://<bucket>/<path>/ | `list(string)` | <pre>[<br>  "gcs://fullstoryapp-warehouse-sync-bundles"<br>]</pre> | no |
 | <a name="input_fullstory_storage_provider"></a> [fullstory\_storage\_provider](#input\_fullstory\_storage\_provider) | The storage provider to use. Either 'S3', 'GCS' or 'AZURE'. This is an advanced option and should only be changed if instructed by Fullstory. | `string` | `"GCS"` | no |
+| <a name="input_password"></a> [password](#input\_password) | The password to use for the Snowflake user. | `string` | `null` | no |
+| <a name="input_role_name"></a> [role\_name](#input\_role\_name) | The name of the Snowflake role to create. | `string` | `null` | no |
+| <a name="input_rsa_public_key"></a> [rsa\_public\_key](#input\_rsa\_public\_key) | The RSA public key to use for the Snowflake user. Must be on 1 line without header and trailer. | `string` | `null` | no |
+| <a name="input_rsa_public_key_2"></a> [rsa\_public\_key\_2](#input\_rsa\_public\_key\_2) | The second RSA public key to use for the Snowflake user. Used when rotating keys. Must be on 1 line without header and trailer. | `string` | `null` | no |
+| <a name="input_stage_name"></a> [stage\_name](#input\_stage\_name) | The name of the Snowflake stage to create. | `string` | `null` | no |
 | <a name="input_suffix"></a> [suffix](#input\_suffix) | The suffix to append to the names of the resources created by this module so that the module can be instantiated many times. Must only contain letters. | `string` | n/a | yes |
 | <a name="input_warehouse_name"></a> [warehouse\_name](#input\_warehouse\_name) | The name of the Snowflake warehouse to use. | `string` | n/a | yes |
 
@@ -33,7 +39,7 @@ This module **does not** create a reader role that can be used to view the data.
 | Name | Description |
 |------|-------------|
 | <a name="output_gcs_storage_integration"></a> [gcs\_storage\_integration](#output\_gcs\_storage\_integration) | The name of the GCS storage integration that can be used in the Fullstory app when configuring the Snowflake integration. |
-| <a name="output_password"></a> [password](#output\_password) | The Fullstory password that can be used in the Fullstory app when configuring the Snowflake integration. |
+| <a name="output_password"></a> [password](#output\_password) | The Fullstory password that can be used in the Fullstory app when configuring the Snowflake integration. Will be empty if `disable_password` is true. |
 | <a name="output_role"></a> [role](#output\_role) | The Fullstory role that can be used in the Fullstory app when configuring the Snowflake integration. |
 | <a name="output_username"></a> [username](#output\_username) | The Fullstory username that can be used in the Fullstory app when configuring the Snowflake integration. |
 

--- a/config.tf
+++ b/config.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     snowflake = {
       source  = "Snowflake-Labs/snowflake"
-      version = ">= 0.83.1"
+      version = "~> 0.83.1"
       configuration_aliases = [
         snowflake.account_admin,
         snowflake.security_admin,

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,7 +9,7 @@ output "username" {
 }
 
 output "password" {
-  description = "The Fullstory password that can be used in the Fullstory app when configuring the Snowflake integration. Will be empty if `disable_password` is true."
+  description = "The password for the configured user that can be used in the Fullstory app when configuring the Snowflake integration. Will be empty if `disable_password` is true."
   value       = snowflake_user.main.password
   sensitive   = true
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,7 +9,7 @@ output "username" {
 }
 
 output "password" {
-  description = "The Fullstory password that can be used in the Fullstory app when configuring the Snowflake integration."
+  description = "The Fullstory password that can be used in the Fullstory app when configuring the Snowflake integration. Will be empty if `disable_password` is true."
   value       = snowflake_user.main.password
   sensitive   = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -3,9 +3,28 @@ variable "database_name" {
   description = "The name of the Snowflake database to use"
 }
 
+variable "role_name" {
+  type = string
+  description = "The name of the Snowflake role to create."
+  default = null
+}
+
+variable "stage_name" {
+  type = string
+  description = "The name of the Snowflake stage to create."
+  default = null
+}
+
+variable "password" {
+  type = string
+  description = "The password to use for the Snowflake user."
+  default = null
+  sensitive = true
+}
+
 variable "fullstory_cidr_ipv4" {
   type        = string
-  description = "The CIDR block that Fullstory will use to connect to the Redshift cluster."
+  description = "The CIDR block that Fullstory will use to connect to Snowflake."
   default     = ""
 }
 
@@ -47,4 +66,22 @@ variable "suffix" {
 variable "warehouse_name" {
   type        = string
   description = "The name of the Snowflake warehouse to use."
+}
+
+variable "disable_password" {
+  type = bool
+  default = false
+  description = "Whether to disable the password for the Snowflake user. If true, the user will only be able to authenticate using the RSA public key."
+}
+
+variable "rsa_public_key" {
+  type = string
+  description = "The RSA public key to use for the Snowflake user. Must be on 1 line without header and trailer."
+  default = null
+}
+
+variable "rsa_public_key_2" {
+  type = string
+  description = "The second RSA public key to use for the Snowflake user. Used when rotating keys. Must be on 1 line without header and trailer."
+  default = null
 }


### PR DESCRIPTION


## Description

Adds the ability to configure an RSA key for the snowflake user. Also adds the ability to configure the names for the resources in case the user wants to use a specific naming scheme.

## Issue or Ticket

https://fullstory.atlassian.net/browse/ACT-960

<!-- Comment this out if you'd like to include more information for an easier review
## Additional Info
 -->

## Checklist before submitting PR for review

- [x] This change requires a doc update, and I've included it
- [x] My code follows the style guidelines of this project
- [x] I have ensured my code is commented and any new terraform variables have proper descriptions
