### PR TITLE
fix: allow more snowflake provider versions

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     snowflake = {
       source  = "Snowflake-Labs/snowflake"
-      version = "~> 0.83.1"
+      version = ">= 0.83.1, < 1.0.0",
       configuration_aliases = [
         snowflake.account_admin,
         snowflake.security_admin,


### PR DESCRIPTION
## Description

Opens up the allowed versions for the snowflake provider. The provider is still pre-1.0.0, and looking at the roadmap, they intend to deprecate some of the resources. I don't believe we are currently using any of them, so hopefully we should be good on constraining to less than 1.0.0.

## Checklist before submitting PR for review

- [ ] This change requires a doc update, and I've included it
- [ ] My code follows the style guidelines of this project
- [ ] I have ensured my code is commented and any new terraform variables have proper descriptions
