### PR TITLE
fix: set default_secondary_roles to ALL

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -51,13 +51,14 @@ resource "random_password" "main" {
 }
 
 resource "snowflake_user" "main" {
-  provider          = snowflake.security_admin
-  name              = "FULLSTORY_WAREHOUSE_SETUP_${local.suffix}"
-  default_warehouse = var.warehouse_name
-  default_role      = snowflake_role.main.name
-  password          = var.manage_password ? random_password.main[0].result : var.password
-  rsa_public_key    = var.rsa_public_key
-  rsa_public_key_2  = var.rsa_public_key_2
+  provider                = snowflake.security_admin
+  name                    = "FULLSTORY_WAREHOUSE_SETUP_${local.suffix}"
+  default_warehouse       = var.warehouse_name
+  default_role            = snowflake_role.main.name
+  password                = var.manage_password ? random_password.main[0].result : var.password
+  rsa_public_key          = var.rsa_public_key
+  rsa_public_key_2        = var.rsa_public_key_2
+  default_secondary_roles = ["ALL"]
 }
 
 resource "snowflake_grant_privileges_to_role" "user" {


### PR DESCRIPTION
## Description

Terraform reports drift since it tries to remove the empty block, see example plan result:
```
  ~ resource "snowflake_user" "main" {
      ~ default_secondary_roles = [
          - jsonencode([]),
        ]
....
```

Snowflake documents the change in default behavior that default_secondary_roles is set to `"ALL"`:
https://community.snowflake.com/s/article/default-secondary-roles-all-overview-and-additional-explanations

For snowflake terraform version `0.83.1`, only `["ALL"]` is supported:
https://registry.terraform.io/providers/Snowflake-Labs/snowflake/0.83.1/docs/resources/user#default_secondary_roles-3

## Checklist before submitting PR for review

- [x] This change requires a doc update, and I've included it
- [x] My code follows the style guidelines of this project
- [x] I have ensured my code is commented and any new terraform variables have proper descriptions
