### PR TITLE
Sabrina/update snowflake depencency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,20 +5,19 @@
 ### BREAKING CHANGES
 
 - **Provider migration**: Switched from `Snowflake-Labs/snowflake` (~> 0.83.1) to `snowflakedb/snowflake` (~> 2.14). Users must update their provider configuration and run `terraform init -upgrade`.
-- **Resource renames**: The following resources have been renamed to match the new provider's requirements. Existing state must be migrated using `terraform state mv` or resources will be destroyed and recreated:
-  - `snowflake_role` → `snowflake_account_role`
-  - `snowflake_grant_privileges_to_role` → `snowflake_grant_privileges_to_account_role`
-  - `snowflake_role_grants` → `snowflake_grant_account_role`
-  - `snowflake_storage_integration` remains `snowflake_storage_integration` (with `storage_provider` attribute)
-- **Attribute changes**:
-  - `role_name` → `account_role_name` on grant resources
-  - `default_secondary_roles` → `default_secondary_roles_option` on user resource
-  - `snowflake_grant_account_role` now uses `user_name` (single string) instead of `users` (list)
-- **Storage integration**: Reverted from `snowflake_storage_integration_gcs` back to `snowflake_storage_integration` with a configurable `fullstory_storage_provider` variable (defaults to `"GCS"`).
+  - **Resource renames**: The following resources have been renamed to match the new provider's requirements. Existing state must be migrated using `terraform state mv` or resources will be destroyed and recreated:
+    - `snowflake_role` → `snowflake_account_role`
+    - `snowflake_grant_privileges_to_role` → `snowflake_grant_privileges_to_account_role`
+    - `snowflake_role_grants` → `snowflake_grant_account_role`
+    - `snowflake_storage_integration` remains `snowflake_storage_integration` (with `storage_provider` attribute)
+  - **Attribute changes**:
+    - `role_name` → `account_role_name` on grant resources
+    - `default_secondary_roles` → `default_secondary_roles_option` on user resource
+    - `snowflake_grant_account_role` now uses `user_name` (single string) instead of `users` (list)
 
 ### Migration Guide
 
-There are two options for migrating to v1.0.0. **Option A** (destroy and recreate) is simpler but causes temporary downtime. **Option B** (manual state migration) avoids downtime by re-importing existing Snowflake resources into the new Terraform state.
+There are two options for migrating to v1.0.0.
 
 #### Option A: Destroy and Recreate (simpler, but causes downtime)
 
@@ -28,7 +27,7 @@ Due to the provider change from `Snowflake-Labs/snowflake` to `snowflakedb/snowf
    ```hcl
    module "fullstory_warehouse_setup" {
      source = "fullstorydev/fullstory-warehouse-setup/snowflake"
-     version ="0.2.3" # your current verison
+     version = "0.2.3" # your current version
      # ...
    }
    ```
@@ -43,13 +42,13 @@ Due to the provider change from `Snowflake-Labs/snowflake` to `snowflakedb/snowf
      # ...
    }
    ```
-6. **Run `terraform plan` and `terraform apply`** to create the new resources.
-8. **Update FullStory** with the new connection details from your Terraform outputs (role, username, password, storage integration).
-9. For resources **outside of this module** (e.g., custom grant resources you manage yourself), follow the [Snowflake provider's Migration Guide](https://registry.terraform.io/providers/snowflakedb/snowflake/latest/docs/guides/resource_migration) to migrate to the new resource types.
+6. **Run `terraform init -upgrade`, `terraform plan` and `terraform apply`** to download the new module and create the new resources.
+7. **Update FullStory** with the new connection details from your Terraform outputs if changed (role, username, key, storage integration).
+8. For resources **outside of this module** (e.g., custom grant resources you manage yourself), follow the [Snowflake provider's Migration Guide](https://registry.terraform.io/providers/snowflakedb/snowflake/latest/docs/guides/resource_migration) to migrate to the new resource types.
 
 #### Option B: Manual State Migration (no downtime)
 
-This approach removes the old resources from Terraform state and imports them back under the new resource types, preserving the actual Snowflake objects. No resources are destroyed or recreated in Snowflake, so there is no downtime.
+This approach removes the old resources from Terraform state and imports them back under the new resource types, preserving the actual Snowflake objects. No resources are destroyed or recreated in **Snowflake**, so there is no downtime.
 
 > **Note**: In the examples below, replace `module.fullstory_warehouse_setup` with the actual module path in your Terraform configuration, and replace `<SUFFIX>` with your configured suffix value (uppercased).
 
@@ -128,6 +127,6 @@ This approach removes the old resources from Terraform state and imports them ba
    - `<WAREHOUSE_NAME>` is your Snowflake warehouse name
    - `<STORAGE_INTEGRATION_NAME>` is the storage integration name (defaults to `FULLSTORY_STAGE_<SUFFIX>` unless you set `stage_name`)
 
-6. **Run `terraform plan`** to verify that no changes are needed. The plan should show no additions, changes, or destructions for the migrated resources. If there are minor diffs (e.g., attribute formatting), review and apply them — these are safe cosmetic updates.
+6. **Run `terraform plan`** to verify that no changes are needed. The plan should show no major additions or destructions for the migrated resources. If there are minor diffs (e.g., attributes defaults in the new providers, etc.), review and apply them.
 
 7. For resources **outside of this module** (e.g., custom grant resources you manage yourself), follow the [Snowflake provider's Migration Guide](https://registry.terraform.io/providers/snowflakedb/snowflake/latest/docs/guides/resource_migration) to migrate to the new resource types.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,133 @@
+# Changelog
+
+## 1.0.0
+
+### BREAKING CHANGES
+
+- **Provider migration**: Switched from `Snowflake-Labs/snowflake` (~> 0.83.1) to `snowflakedb/snowflake` (~> 2.14). Users must update their provider configuration and run `terraform init -upgrade`.
+- **Resource renames**: The following resources have been renamed to match the new provider's requirements. Existing state must be migrated using `terraform state mv` or resources will be destroyed and recreated:
+  - `snowflake_role` → `snowflake_account_role`
+  - `snowflake_grant_privileges_to_role` → `snowflake_grant_privileges_to_account_role`
+  - `snowflake_role_grants` → `snowflake_grant_account_role`
+  - `snowflake_storage_integration` remains `snowflake_storage_integration` (with `storage_provider` attribute)
+- **Attribute changes**:
+  - `role_name` → `account_role_name` on grant resources
+  - `default_secondary_roles` → `default_secondary_roles_option` on user resource
+  - `snowflake_grant_account_role` now uses `user_name` (single string) instead of `users` (list)
+- **Storage integration**: Reverted from `snowflake_storage_integration_gcs` back to `snowflake_storage_integration` with a configurable `fullstory_storage_provider` variable (defaults to `"GCS"`).
+
+### Migration Guide
+
+There are two options for migrating to v1.0.0. **Option A** (destroy and recreate) is simpler but causes temporary downtime. **Option B** (manual state migration) avoids downtime by re-importing existing Snowflake resources into the new Terraform state.
+
+#### Option A: Destroy and Recreate (simpler, but causes downtime)
+
+Due to the provider change from `Snowflake-Labs/snowflake` to `snowflakedb/snowflake`, the simplest migration path is to destroy the old module resources and recreate them with the new version. FullStory will temporarily lose the ability to sync data to your warehouse during this process.
+
+1. **Remove the module block** from your Terraform configuration. For example, remove or comment out:
+   ```hcl
+   module "fullstory_warehouse_setup" {
+     source = "fullstorydev/fullstory-warehouse-setup/snowflake"
+     version ="0.2.3" # your current verison
+     # ...
+   }
+   ```
+2. **Run `terraform plan` and `terraform apply`** to destroy the old module's resources (role, user, grants, storage integration, network policy).
+3. **Update your provider configuration** to use `snowflakedb/snowflake` ~> 2.14.
+4. **Run `terraform init -upgrade`** to download the new provider.
+5. **Add the module block back** with the new version:
+   ```hcl
+   module "fullstory_warehouse_setup" {
+     source  = "fullstorydev/fullstory-warehouse-setup/snowflake"
+     version = "~> 1.0"
+     # ...
+   }
+   ```
+6. **Run `terraform plan` and `terraform apply`** to create the new resources.
+8. **Update FullStory** with the new connection details from your Terraform outputs (role, username, password, storage integration).
+9. For resources **outside of this module** (e.g., custom grant resources you manage yourself), follow the [Snowflake provider's Migration Guide](https://registry.terraform.io/providers/snowflakedb/snowflake/latest/docs/guides/resource_migration) to migrate to the new resource types.
+
+#### Option B: Manual State Migration (no downtime)
+
+This approach removes the old resources from Terraform state and imports them back under the new resource types, preserving the actual Snowflake objects. No resources are destroyed or recreated in Snowflake, so there is no downtime.
+
+> **Note**: In the examples below, replace `module.fullstory_warehouse_setup` with the actual module path in your Terraform configuration, and replace `<SUFFIX>` with your configured suffix value (uppercased).
+
+1. **List existing resources** to identify what needs to be migrated:
+   ```bash
+   terraform state list | grep fullstory_warehouse_setup
+   ```
+   You should see resources like:
+   ```
+   module.fullstory_warehouse_setup.snowflake_role.main
+   module.fullstory_warehouse_setup.snowflake_grant_privileges_to_role.database
+   module.fullstory_warehouse_setup.snowflake_grant_privileges_to_role.warehouse
+   module.fullstory_warehouse_setup.snowflake_grant_privileges_to_role.user
+   module.fullstory_warehouse_setup.snowflake_grant_privileges_to_role.integration
+   module.fullstory_warehouse_setup.snowflake_role_grants.main
+   module.fullstory_warehouse_setup.snowflake_storage_integration.main
+   ```
+
+2. **Remove the old resources from state** (this does NOT delete the actual Snowflake objects):
+   ```bash
+   # Remove the role
+   terraform state rm 'module.fullstory_warehouse_setup.snowflake_role.main'
+
+   # Remove all grant_privileges_to_role resources
+   terraform state rm 'module.fullstory_warehouse_setup.snowflake_grant_privileges_to_role.database'
+   terraform state rm 'module.fullstory_warehouse_setup.snowflake_grant_privileges_to_role.warehouse'
+   terraform state rm 'module.fullstory_warehouse_setup.snowflake_grant_privileges_to_role.user'
+   terraform state rm 'module.fullstory_warehouse_setup.snowflake_grant_privileges_to_role.integration'
+
+   # Remove the role grants
+   terraform state rm 'module.fullstory_warehouse_setup.snowflake_role_grants.main'
+
+   # Remove the storage integration
+   terraform state rm 'module.fullstory_warehouse_setup.snowflake_storage_integration.main'
+   ```
+
+3. **Update your provider configuration** to use `snowflakedb/snowflake` ~> 2.14, and **update the module version** to `~> 1.0`:
+   ```hcl
+   module "fullstory_warehouse_setup" {
+     source  = "fullstorydev/fullstory-warehouse-setup/snowflake"
+     version = "~> 1.0"
+     # ...
+   }
+   ```
+
+4. **Run `terraform init -upgrade`** to download the new provider.
+
+5. **Import the resources back** under the new resource types. The resources still exist in Snowflake and just need to be re-associated with the new Terraform resource names:
+   ```bash
+   # Import the role (snowflake_role → snowflake_account_role)
+   terraform import 'module.fullstory_warehouse_setup.snowflake_account_role.main' '"FULLSTORY_WAREHOUSE_SETUP_<SUFFIX>"'
+
+   # Import grant_privileges_to_account_role resources (snowflake_grant_privileges_to_role → snowflake_grant_privileges_to_account_role)
+   # Format: <account_role_name>|<with_grant_option>|<always_apply>|<all_privileges>|<privileges>|<grant_type>|<grant_data>
+   terraform import 'module.fullstory_warehouse_setup.snowflake_grant_privileges_to_account_role.database' \
+     '"FULLSTORY_WAREHOUSE_SETUP_<SUFFIX>"|false|false|true||OnAccountObject|DATABASE|"<DATABASE_NAME>"'
+   terraform import 'module.fullstory_warehouse_setup.snowflake_grant_privileges_to_account_role.warehouse' \
+     '"FULLSTORY_WAREHOUSE_SETUP_<SUFFIX>"|false|false|false|USAGE|OnAccountObject|WAREHOUSE|"<WAREHOUSE_NAME>"'
+   terraform import 'module.fullstory_warehouse_setup.snowflake_grant_privileges_to_account_role.user' \
+     '"FULLSTORY_WAREHOUSE_SETUP_<SUFFIX>"|false|false|false|MONITOR|OnAccountObject|USER|"FULLSTORY_WAREHOUSE_SETUP_<SUFFIX>"'
+   terraform import 'module.fullstory_warehouse_setup.snowflake_grant_privileges_to_account_role.integration' \
+     '"FULLSTORY_WAREHOUSE_SETUP_<SUFFIX>"|false|false|false|USAGE|OnAccountObject|INTEGRATION|"<STORAGE_INTEGRATION_NAME>"'
+
+   # Import the role grant (snowflake_role_grants → snowflake_grant_account_role)
+   # Format: <role_name>|USER|<user_name>
+   terraform import 'module.fullstory_warehouse_setup.snowflake_grant_account_role.main' \
+     '"FULLSTORY_WAREHOUSE_SETUP_<SUFFIX>"|USER|"FULLSTORY_WAREHOUSE_SETUP_<SUFFIX>"'
+
+   # Import the storage integration
+   terraform import 'module.fullstory_warehouse_setup.snowflake_storage_integration.main' '"<STORAGE_INTEGRATION_NAME>"'
+   ```
+
+   Where:
+   - `<SUFFIX>` is your configured suffix value (uppercased), e.g. `ACME`
+   - `<DATABASE_NAME>` is your Snowflake database name
+   - `<WAREHOUSE_NAME>` is your Snowflake warehouse name
+   - `<STORAGE_INTEGRATION_NAME>` is the storage integration name (defaults to `FULLSTORY_STAGE_<SUFFIX>` unless you set `stage_name`)
+
+6. **Run `terraform plan`** to verify that no changes are needed. The plan should show no additions, changes, or destructions for the migrated resources. If there are minor diffs (e.g., attribute formatting), review and apply them — these are safe cosmetic updates.
+
+7. For resources **outside of this module** (e.g., custom grant resources you manage yourself), follow the [Snowflake provider's Migration Guide](https://registry.terraform.io/providers/snowflakedb/snowflake/latest/docs/guides/resource_migration) to migrate to the new resource types.

--- a/README.md
+++ b/README.md
@@ -25,11 +25,12 @@ This module **does not** create a reader role that can be used to view the data.
 | <a name="input_fullstory_cidr_ipv4s"></a> [fullstory\_cidr\_ipv4s](#input\_fullstory\_cidr\_ipv4s) | The CIDR blocks that Fullstory will use to connect to Snowflake. | `list(string)` | `[]` | no |
 | <a name="input_fullstory_data_center"></a> [fullstory\_data\_center](#input\_fullstory\_data\_center) | The data center where your Fullstory account is hosted. Either 'NA1' or 'EU1'. See https://help.fullstory.com/hc/en-us/articles/8901113940375-Fullstory-Data-Residency for more information. | `string` | `"NA1"` | no |
 | <a name="input_fullstory_storage_allowed_locations"></a> [fullstory\_storage\_allowed\_locations](#input\_fullstory\_storage\_allowed\_locations) | The list of allowed locations for the storage provider. This is an advanced option and should only be changed if instructed by Fullstory. Ex. <cloud>://<bucket>/<path>/ | `list(string)` | <pre>[<br>  "gcs://fullstoryapp-warehouse-sync-bundles"<br>]</pre> | no |
+| <a name="input_fullstory_storage_provider"></a> [fullstory\_storage\_provider](#input\_fullstory\_storage\_provider) | The storage provider for the storage integration. This is an advanced option and should only be changed if instructed by Fullstory. | `string` | `"GCS"` | no |
 | <a name="input_manage_password"></a> [manage\_password](#input\_manage\_password) | Whether to create a random password and use it for the Snowflake user. If false and no password or RSA public key is provided, the user will be created without a password. | `bool` | `true` | no |
 | <a name="input_password"></a> [password](#input\_password) | The password to use for the Snowflake user. Use manage\_password=true if you want to generate a random password. | `string` | `null` | no |
 | <a name="input_role_name"></a> [role\_name](#input\_role\_name) | The name of the Snowflake role to create. | `string` | `null` | no |
-| <a name="input_rsa_public_key"></a> [rsa\_public\_key](#input\_rsa\_public\_key) | The RSA public key to use for the Snowflake user. Must be on 1 line without header and trailer. | `string` | `null` | no |
-| <a name="input_rsa_public_key_2"></a> [rsa\_public\_key\_2](#input\_rsa\_public\_key\_2) | The second RSA public key to use for the Snowflake user. Used when rotating keys. Must be on 1 line without header and trailer. | `string` | `null` | no |
+| <a name="input_rsa_public_key"></a> [rsa\_public\_key](#input\_rsa\_public\_key) | The RSA public key to use for the Snowflake user. Accepts PEM format (e.g. from tls\_private\_key resource's public\_key\_pem output). | `string` | `null` | no |
+| <a name="input_rsa_public_key_2"></a> [rsa\_public\_key\_2](#input\_rsa\_public\_key\_2) | The second RSA public key to use for the Snowflake user. Used when rotating keys. Accepts PEM format (e.g. from tls\_private\_key resource's public\_key\_pem output). | `string` | `null` | no |
 | <a name="input_stage_name"></a> [stage\_name](#input\_stage\_name) | The name of the Snowflake stage to create. | `string` | `null` | no |
 | <a name="input_suffix"></a> [suffix](#input\_suffix) | The suffix to append to the names of the resources created by this module so that the module can be instantiated many times. Must only contain letters. | `string` | n/a | yes |
 | <a name="input_warehouse_name"></a> [warehouse\_name](#input\_warehouse\_name) | The name of the Snowflake warehouse to use. | `string` | n/a | yes |
@@ -39,7 +40,7 @@ This module **does not** create a reader role that can be used to view the data.
 | Name | Description |
 |------|-------------|
 | <a name="output_gcs_storage_integration"></a> [gcs\_storage\_integration](#output\_gcs\_storage\_integration) | The name of the GCS storage integration that can be used in the Fullstory app when configuring the Snowflake integration. |
-| <a name="output_password"></a> [password](#output\_password) | The password for the configured user that can be used in the Fullstory app when configuring the Snowflake integration. Will be empty if `disable_password` is true. |
+| <a name="output_password"></a> [password](#output\_password) | The password for the configured user that can be used in the Fullstory app when configuring the Snowflake integration. Will be empty if `manage_password` is false. |
 | <a name="output_role"></a> [role](#output\_role) | The Fullstory role that can be used in the Fullstory app when configuring the Snowflake integration. |
 | <a name="output_username"></a> [username](#output\_username) | The Fullstory username that can be used in the Fullstory app when configuring the Snowflake integration. |
 
@@ -56,8 +57,14 @@ resource "snowflake_warehouse" "main" {
   auto_suspend   = 60
 }
 
+resource "tls_private_key" "fullstory_user_rsa_key" {
+  algorithm = "RSA"
+  rsa_bits  = 2048
+}
+
 module "fullstory_warehouse_setup" {
-  source = "fullstorydev/fullstory-warehouse-setup/snowflake"
+  source  = "fullstorydev/fullstory-warehouse-setup/snowflake"
+  version = "~> 1.0"
   providers = {
     snowflake.account_admin  = snowflake.account_admin
     snowflake.security_admin = snowflake.security_admin
@@ -67,6 +74,7 @@ module "fullstory_warehouse_setup" {
   database_name         = snowflake_database.main.name
   warehouse_name        = snowflake_warehouse.main.name
   fullstory_data_center = "NA1"
+  rsa_public_key        = tls_private_key.fullstory_user_rsa_key.public_key_pem
   suffix                = "ACME" # This should represent this module's unique identifier
 }
 
@@ -79,7 +87,13 @@ output "fullstory_warehouse_setup_username" {
 }
 
 output "fullstory_warehouse_setup_password" {
-  value = module.fullstory_warehouse_setup.password
+  value     = module.fullstory_warehouse_setup.password
+  sensitive = true
+}
+
+output "fullstory_warehouse_setup_private_key" {
+  value     = tls_private_key.fullstory_user_rsa_key.private_key_pem
+  sensitive = true
 }
 
 output "fullstory_warehouse_setup_gcs_storage_integration" {

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This module **does not** create a reader role that can be used to view the data.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
-| <a name="requirement_snowflake"></a> [snowflake](#requirement\_snowflake) | ~> 0.83.1 |
+| <a name="requirement_snowflake"></a> [snowflake](#requirement\_snowflake) | ~> 2.14 |
 
 ## Inputs
 
@@ -25,7 +25,6 @@ This module **does not** create a reader role that can be used to view the data.
 | <a name="input_fullstory_cidr_ipv4s"></a> [fullstory\_cidr\_ipv4s](#input\_fullstory\_cidr\_ipv4s) | The CIDR blocks that Fullstory will use to connect to Snowflake. | `list(string)` | `[]` | no |
 | <a name="input_fullstory_data_center"></a> [fullstory\_data\_center](#input\_fullstory\_data\_center) | The data center where your Fullstory account is hosted. Either 'NA1' or 'EU1'. See https://help.fullstory.com/hc/en-us/articles/8901113940375-Fullstory-Data-Residency for more information. | `string` | `"NA1"` | no |
 | <a name="input_fullstory_storage_allowed_locations"></a> [fullstory\_storage\_allowed\_locations](#input\_fullstory\_storage\_allowed\_locations) | The list of allowed locations for the storage provider. This is an advanced option and should only be changed if instructed by Fullstory. Ex. <cloud>://<bucket>/<path>/ | `list(string)` | <pre>[<br>  "gcs://fullstoryapp-warehouse-sync-bundles"<br>]</pre> | no |
-| <a name="input_fullstory_storage_provider"></a> [fullstory\_storage\_provider](#input\_fullstory\_storage\_provider) | The storage provider to use. Either 'S3', 'GCS' or 'AZURE'. This is an advanced option and should only be changed if instructed by Fullstory. | `string` | `"GCS"` | no |
 | <a name="input_manage_password"></a> [manage\_password](#input\_manage\_password) | Whether to create a random password and use it for the Snowflake user. If false and no password or RSA public key is provided, the user will be created without a password. | `bool` | `true` | no |
 | <a name="input_password"></a> [password](#input\_password) | The password to use for the Snowflake user. Use manage\_password=true if you want to generate a random password. | `string` | `null` | no |
 | <a name="input_role_name"></a> [role\_name](#input\_role\_name) | The name of the Snowflake role to create. | `string` | `null` | no |
@@ -91,14 +90,14 @@ output "fullstory_warehouse_setup_gcs_storage_integration" {
 ### Creating a READER role
 This module **does not** create a READER role. You can use the following example to create a READER role that will allow a user to use and read all objects _and_ all future objects in the database.
 ```hcl
-resource "snowflake_role" "data_user_role" {
+resource "snowflake_account_role" "data_user_role" {
   provider = snowflake.security_admin
   name     = "READER"
 }
 
-resource "snowflake_grant_privileges_to_role" "data_user_database" {
-  provider  = snowflake.security_admin
-  role_name = snowflake_role.data_user_role.name
+resource "snowflake_grant_privileges_to_account_role" "data_user_database" {
+  provider          = snowflake.security_admin
+  account_role_name = snowflake_account_role.data_user_role.name
 
   privileges = ["USAGE", "MONITOR"]
   on_account_object {
@@ -107,9 +106,9 @@ resource "snowflake_grant_privileges_to_role" "data_user_database" {
   }
 }
 
-resource "snowflake_grant_privileges_to_role" "data_user_schema" {
-  provider  = snowflake.security_admin
-  role_name = snowflake_role.data_user_role.name
+resource "snowflake_grant_privileges_to_account_role" "data_user_schema" {
+  provider          = snowflake.security_admin
+  account_role_name = snowflake_account_role.data_user_role.name
 
   privileges = [
     "USAGE",
@@ -120,9 +119,9 @@ resource "snowflake_grant_privileges_to_role" "data_user_schema" {
   }
 }
 
-resource "snowflake_grant_privileges_to_role" "data_user_future_schema" {
-  provider  = snowflake.security_admin
-  role_name = snowflake_role.data_user_role.name
+resource "snowflake_grant_privileges_to_account_role" "data_user_future_schema" {
+  provider          = snowflake.security_admin
+  account_role_name = snowflake_account_role.data_user_role.name
 
   privileges = [
     "USAGE",
@@ -133,9 +132,9 @@ resource "snowflake_grant_privileges_to_role" "data_user_future_schema" {
   }
 }
 
-resource "snowflake_grant_privileges_to_role" "data_user_tables" {
-  provider  = snowflake.security_admin
-  role_name = snowflake_role.data_user_role.name
+resource "snowflake_grant_privileges_to_account_role" "data_user_tables" {
+  provider          = snowflake.security_admin
+  account_role_name = snowflake_account_role.data_user_role.name
 
   privileges = ["SELECT"]
   on_schema_object {
@@ -146,9 +145,9 @@ resource "snowflake_grant_privileges_to_role" "data_user_tables" {
   }
 }
 
-resource "snowflake_grant_privileges_to_role" "data_user_future_tables" {
-  provider  = snowflake.security_admin
-  role_name = snowflake_role.data_user_role.name
+resource "snowflake_grant_privileges_to_account_role" "data_user_future_tables" {
+  provider          = snowflake.security_admin
+  account_role_name = snowflake_account_role.data_user_role.name
 
   privileges = ["SELECT"]
   on_schema_object {
@@ -159,9 +158,9 @@ resource "snowflake_grant_privileges_to_role" "data_user_future_tables" {
   }
 }
 
-resource "snowflake_grant_privileges_to_role" "data_user_views" {
-  provider  = snowflake.security_admin
-  role_name = snowflake_role.data_user_role.name
+resource "snowflake_grant_privileges_to_account_role" "data_user_views" {
+  provider          = snowflake.security_admin
+  account_role_name = snowflake_account_role.data_user_role.name
 
   privileges = ["SELECT"]
   on_schema_object {
@@ -172,9 +171,9 @@ resource "snowflake_grant_privileges_to_role" "data_user_views" {
   }
 }
 
-resource "snowflake_grant_privileges_to_role" "data_user_future_views" {
-  provider  = snowflake.security_admin
-  role_name = snowflake_role.data_user_role.name
+resource "snowflake_grant_privileges_to_account_role" "data_user_future_views" {
+  provider          = snowflake.security_admin
+  account_role_name = snowflake_account_role.data_user_role.name
 
   privileges = ["SELECT"]
   on_schema_object {
@@ -185,9 +184,9 @@ resource "snowflake_grant_privileges_to_role" "data_user_future_views" {
   }
 }
 
-resource "snowflake_grant_privileges_to_role" "data_user_mat_views" {
-  provider  = snowflake.security_admin
-  role_name = snowflake_role.data_user_role.name
+resource "snowflake_grant_privileges_to_account_role" "data_user_mat_views" {
+  provider          = snowflake.security_admin
+  account_role_name = snowflake_account_role.data_user_role.name
 
   privileges = ["SELECT"]
   on_schema_object {
@@ -199,9 +198,9 @@ resource "snowflake_grant_privileges_to_role" "data_user_mat_views" {
 }
 
 
-resource "snowflake_grant_privileges_to_role" "data_user_future_mat_views" {
-  provider  = snowflake.security_admin
-  role_name = snowflake_role.data_user_role.name
+resource "snowflake_grant_privileges_to_account_role" "data_user_future_mat_views" {
+  provider          = snowflake.security_admin
+  account_role_name = snowflake_account_role.data_user_role.name
 
   privileges = ["SELECT"]
   on_schema_object {

--- a/config.tf
+++ b/config.tf
@@ -3,8 +3,8 @@ terraform {
 
   required_providers {
     snowflake = {
-      source  = "Snowflake-Labs/snowflake"
-      version = "~> 0.83.1"
+      source  = "snowflakedb/snowflake"
+      version = "~> 2.14"
       configuration_aliases = [
         snowflake.account_admin,
         snowflake.security_admin,

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -8,8 +8,14 @@ resource "snowflake_warehouse" "main" {
   auto_suspend   = 60
 }
 
+resource "tls_private_key" "fullstory_user_rsa_key" {
+  algorithm = "RSA"
+  rsa_bits  = 2048
+}
+
 module "fullstory_warehouse_setup" {
-  source = "fullstorydev/fullstory-warehouse-setup/snowflake"
+  source  = "fullstorydev/fullstory-warehouse-setup/snowflake"
+  version = "~> 1.0"
   providers = {
     snowflake.account_admin  = snowflake.account_admin
     snowflake.security_admin = snowflake.security_admin
@@ -19,6 +25,7 @@ module "fullstory_warehouse_setup" {
   database_name         = snowflake_database.main.name
   warehouse_name        = snowflake_warehouse.main.name
   fullstory_data_center = "NA1"
+  rsa_public_key        = tls_private_key.fullstory_user_rsa_key.public_key_pem
   suffix                = "ACME" # This should represent this module's unique identifier
 }
 
@@ -31,7 +38,13 @@ output "fullstory_warehouse_setup_username" {
 }
 
 output "fullstory_warehouse_setup_password" {
-  value = module.fullstory_warehouse_setup.password
+  value     = module.fullstory_warehouse_setup.password
+  sensitive = true
+}
+
+output "fullstory_warehouse_setup_private_key" {
+  value     = tls_private_key.fullstory_user_rsa_key.private_key_pem
+  sensitive = true
 }
 
 output "fullstory_warehouse_setup_gcs_storage_integration" {

--- a/examples/reader_role/main.tf
+++ b/examples/reader_role/main.tf
@@ -1,11 +1,11 @@
-resource "snowflake_role" "data_user_role" {
+resource "snowflake_account_role" "data_user_role" {
   provider = snowflake.security_admin
   name     = "READER"
 }
 
-resource "snowflake_grant_privileges_to_role" "data_user_database" {
-  provider  = snowflake.security_admin
-  role_name = snowflake_role.data_user_role.name
+resource "snowflake_grant_privileges_to_account_role" "data_user_database" {
+  provider          = snowflake.security_admin
+  account_role_name = snowflake_account_role.data_user_role.name
 
   privileges = ["USAGE", "MONITOR"]
   on_account_object {
@@ -14,9 +14,9 @@ resource "snowflake_grant_privileges_to_role" "data_user_database" {
   }
 }
 
-resource "snowflake_grant_privileges_to_role" "data_user_schema" {
-  provider  = snowflake.security_admin
-  role_name = snowflake_role.data_user_role.name
+resource "snowflake_grant_privileges_to_account_role" "data_user_schema" {
+  provider          = snowflake.security_admin
+  account_role_name = snowflake_account_role.data_user_role.name
 
   privileges = [
     "USAGE",
@@ -27,9 +27,9 @@ resource "snowflake_grant_privileges_to_role" "data_user_schema" {
   }
 }
 
-resource "snowflake_grant_privileges_to_role" "data_user_future_schema" {
-  provider  = snowflake.security_admin
-  role_name = snowflake_role.data_user_role.name
+resource "snowflake_grant_privileges_to_account_role" "data_user_future_schema" {
+  provider          = snowflake.security_admin
+  account_role_name = snowflake_account_role.data_user_role.name
 
   privileges = [
     "USAGE",
@@ -40,9 +40,9 @@ resource "snowflake_grant_privileges_to_role" "data_user_future_schema" {
   }
 }
 
-resource "snowflake_grant_privileges_to_role" "data_user_tables" {
-  provider  = snowflake.security_admin
-  role_name = snowflake_role.data_user_role.name
+resource "snowflake_grant_privileges_to_account_role" "data_user_tables" {
+  provider          = snowflake.security_admin
+  account_role_name = snowflake_account_role.data_user_role.name
 
   privileges = ["SELECT"]
   on_schema_object {
@@ -53,9 +53,9 @@ resource "snowflake_grant_privileges_to_role" "data_user_tables" {
   }
 }
 
-resource "snowflake_grant_privileges_to_role" "data_user_future_tables" {
-  provider  = snowflake.security_admin
-  role_name = snowflake_role.data_user_role.name
+resource "snowflake_grant_privileges_to_account_role" "data_user_future_tables" {
+  provider          = snowflake.security_admin
+  account_role_name = snowflake_account_role.data_user_role.name
 
   privileges = ["SELECT"]
   on_schema_object {
@@ -66,9 +66,9 @@ resource "snowflake_grant_privileges_to_role" "data_user_future_tables" {
   }
 }
 
-resource "snowflake_grant_privileges_to_role" "data_user_views" {
-  provider  = snowflake.security_admin
-  role_name = snowflake_role.data_user_role.name
+resource "snowflake_grant_privileges_to_account_role" "data_user_views" {
+  provider          = snowflake.security_admin
+  account_role_name = snowflake_account_role.data_user_role.name
 
   privileges = ["SELECT"]
   on_schema_object {
@@ -79,9 +79,9 @@ resource "snowflake_grant_privileges_to_role" "data_user_views" {
   }
 }
 
-resource "snowflake_grant_privileges_to_role" "data_user_future_views" {
-  provider  = snowflake.security_admin
-  role_name = snowflake_role.data_user_role.name
+resource "snowflake_grant_privileges_to_account_role" "data_user_future_views" {
+  provider          = snowflake.security_admin
+  account_role_name = snowflake_account_role.data_user_role.name
 
   privileges = ["SELECT"]
   on_schema_object {
@@ -92,9 +92,9 @@ resource "snowflake_grant_privileges_to_role" "data_user_future_views" {
   }
 }
 
-resource "snowflake_grant_privileges_to_role" "data_user_mat_views" {
-  provider  = snowflake.security_admin
-  role_name = snowflake_role.data_user_role.name
+resource "snowflake_grant_privileges_to_account_role" "data_user_mat_views" {
+  provider          = snowflake.security_admin
+  account_role_name = snowflake_account_role.data_user_role.name
 
   privileges = ["SELECT"]
   on_schema_object {
@@ -106,9 +106,9 @@ resource "snowflake_grant_privileges_to_role" "data_user_mat_views" {
 }
 
 
-resource "snowflake_grant_privileges_to_role" "data_user_future_mat_views" {
-  provider  = snowflake.security_admin
-  role_name = snowflake_role.data_user_role.name
+resource "snowflake_grant_privileges_to_account_role" "data_user_future_mat_views" {
+  provider          = snowflake.security_admin
+  account_role_name = snowflake_account_role.data_user_role.name
 
   privileges = ["SELECT"]
   on_schema_object {

--- a/main.tf
+++ b/main.tf
@@ -4,6 +4,10 @@ locals {
   fullstory_cidr_ipv4s       = length(var.fullstory_cidr_ipv4s) > 0 ? var.fullstory_cidr_ipv4s : [local.fullstory_cidr_ipv4]
 
   suffix = upper(var.suffix)
+
+  storage_integration_name = coalesce(var.stage_name, "FULLSTORY_STAGE_${local.suffix}")
+  role_name                = coalesce(var.role_name, "FULLSTORY_WAREHOUSE_SETUP_${local.suffix}")
+  user_name                = "FULLSTORY_WAREHOUSE_SETUP_${local.suffix}"
 }
 
 provider "snowflake" {
@@ -18,25 +22,25 @@ provider "snowflake" {
   alias = "sys_admin"
 }
 
-resource "snowflake_role" "main" {
+resource "snowflake_account_role" "main" {
   provider = snowflake.security_admin
-  name     = coalesce(var.role_name, "FULLSTORY_WAREHOUSE_SETUP_${local.suffix}")
+  name     = local.role_name
 }
 
-resource "snowflake_grant_privileges_to_role" "database" {
-  provider       = snowflake.security_admin
-  all_privileges = true
-  role_name      = snowflake_role.main.name
+resource "snowflake_grant_privileges_to_account_role" "database" {
+  provider          = snowflake.security_admin
+  all_privileges    = true
+  account_role_name = snowflake_account_role.main.name
   on_account_object {
     object_type = "DATABASE"
     object_name = var.database_name
   }
 }
 
-resource "snowflake_grant_privileges_to_role" "warehouse" {
-  provider   = snowflake.security_admin
-  role_name  = snowflake_role.main.name
-  privileges = ["USAGE"]
+resource "snowflake_grant_privileges_to_account_role" "warehouse" {
+  provider          = snowflake.security_admin
+  account_role_name = snowflake_account_role.main.name
+  privileges        = ["USAGE"]
   on_account_object {
     object_type = "WAREHOUSE"
     object_name = var.warehouse_name
@@ -51,49 +55,46 @@ resource "random_password" "main" {
 }
 
 resource "snowflake_user" "main" {
-  provider                = snowflake.security_admin
-  name                    = "FULLSTORY_WAREHOUSE_SETUP_${local.suffix}"
-  default_warehouse       = var.warehouse_name
-  default_role            = snowflake_role.main.name
-  password                = var.manage_password ? random_password.main[0].result : var.password
-  rsa_public_key          = var.rsa_public_key
-  rsa_public_key_2        = var.rsa_public_key_2
-  default_secondary_roles = ["ALL"]
+  provider                       = snowflake.security_admin
+  name                           = "FULLSTORY_WAREHOUSE_SETUP_${local.suffix}"
+  default_warehouse              = var.warehouse_name
+  default_role                   = snowflake_account_role.main.name
+  password                       = var.manage_password ? random_password.main[0].result : var.password
+  rsa_public_key                 = var.rsa_public_key
+  rsa_public_key_2               = var.rsa_public_key_2
+  default_secondary_roles_option = "ALL"
 }
 
-resource "snowflake_grant_privileges_to_role" "user" {
-  provider   = snowflake.security_admin
-  role_name  = snowflake_role.main.name
-  privileges = ["MONITOR"]
+resource "snowflake_grant_privileges_to_account_role" "user" {
+  provider          = snowflake.security_admin
+  account_role_name = snowflake_account_role.main.name
+  privileges        = ["MONITOR"]
   on_account_object {
     object_type = "USER"
     object_name = snowflake_user.main.name
   }
 }
 
-resource "snowflake_role_grants" "main" {
+resource "snowflake_grant_account_role" "main" {
   provider  = snowflake.security_admin
-  role_name = snowflake_role.main.name
-  users = [
-    snowflake_user.main.name,
-  ]
+  role_name = snowflake_account_role.main.name
+  user_name = snowflake_user.main.name
 }
 
 resource "snowflake_storage_integration" "main" {
-  provider = snowflake.account_admin
-  name     = coalesce(var.stage_name, "FULLSTORY_STAGE_${local.suffix}")
-  comment  = "Stage for FullStory data"
-  type     = "EXTERNAL_STAGE"
-  enabled  = true
+  provider         = snowflake.account_admin
+  name             = local.storage_integration_name
+  comment          = "Stage for FullStory data"
+  enabled          = true
+  storage_provider = var.fullstory_storage_provider
 
-  storage_provider          = var.fullstory_storage_provider
   storage_allowed_locations = var.fullstory_storage_allowed_locations
 }
 
-resource "snowflake_grant_privileges_to_role" "integration" {
-  provider   = snowflake.security_admin
-  role_name  = snowflake_role.main.name
-  privileges = ["USAGE"]
+resource "snowflake_grant_privileges_to_account_role" "integration" {
+  provider          = snowflake.security_admin
+  account_role_name = snowflake_account_role.main.name
+  privileges        = ["USAGE"]
   on_account_object {
     object_type = "INTEGRATION"
     object_name = snowflake_storage_integration.main.name

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,7 +9,7 @@ output "username" {
 }
 
 output "password" {
-  description = "The password for the configured user that can be used in the Fullstory app when configuring the Snowflake integration. Will be empty if `disable_password` is true."
+  description = "The password for the configured user that can be used in the Fullstory app when configuring the Snowflake integration. Will be empty if `manage_password` is false."
   value       = snowflake_user.main.password
   sensitive   = true
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 output "role" {
   description = "The Fullstory role that can be used in the Fullstory app when configuring the Snowflake integration."
-  value       = snowflake_role.main.name
+  value       = snowflake_account_role.main.name
 }
 
 output "username" {

--- a/variables.tf
+++ b/variables.tf
@@ -80,12 +80,12 @@ variable "manage_password" {
 
 variable "rsa_public_key" {
   type        = string
-  description = "The RSA public key to use for the Snowflake user. Must be on 1 line without header and trailer."
+  description = "The RSA public key to use for the Snowflake user. Accepts PEM format (e.g. from tls_private_key resource's public_key_pem output)."
   default     = null
 }
 
 variable "rsa_public_key_2" {
   type        = string
-  description = "The second RSA public key to use for the Snowflake user. Used when rotating keys. Must be on 1 line without header and trailer."
+  description = "The second RSA public key to use for the Snowflake user. Used when rotating keys. Accepts PEM format (e.g. from tls_private_key resource's public_key_pem output)."
   default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -44,21 +44,19 @@ variable "fullstory_data_center" {
   }
 }
 
+variable "fullstory_storage_provider" {
+  type        = string
+  description = "The storage provider for the storage integration. This is an advanced option and should only be changed if instructed by Fullstory."
+  default     = "GCS"
+}
+
 variable "fullstory_storage_allowed_locations" {
   type        = list(string)
   description = "The list of allowed locations for the storage provider. This is an advanced option and should only be changed if instructed by Fullstory. Ex. <cloud>://<bucket>/<path>/"
   default     = ["gcs://fullstoryapp-warehouse-sync-bundles"]
 }
 
-variable "fullstory_storage_provider" {
-  type        = string
-  description = "The storage provider to use. Either 'S3', 'GCS' or 'AZURE'. This is an advanced option and should only be changed if instructed by Fullstory."
-  validation {
-    condition     = var.fullstory_storage_provider == "S3" || var.fullstory_storage_provider == "GCS" || var.fullstory_storage_provider == "AZURE"
-    error_message = "The storage provider must be either 'S3', 'GCS', or 'AZURE'."
-  }
-  default = "GCS"
-}
+
 
 variable "suffix" {
   type        = string


### PR DESCRIPTION
## Description

Migrate the Snowflake Terraform provider from `Snowflake-Labs/snowflake` (`~> 0.83.1`) to the official `snowflakedb/snowflake` (`~> 2.14`) provider. This is a breaking change that renames several resources to match the new provider's API:                                                                                                                       
                                                                                                                                                                                   
  - `snowflake_role` → `snowflake_account_role`                                                                                                                                  
  - `snowflake_grant_privileges_to_role` → `snowflake_grant_privileges_to_account_role` (with `role_name` → `account_role_name`)
  - `snowflake_role_grants` → `snowflake_grant_account_role` (with `users` list → single `user_name`)
  - `snowflake_storage_integration` → `snowflake_storage_integration_gcs`
  - `default_secondary_roles` → `default_secondary_roles_option on the user resource`

## Issue or Ticket

N/A

## Checklist before submitting PR for review

- [x] This change requires a doc update, and I've included it
- [x] My code follows the style guidelines of this project
- [x] I have ensured my code is commented and any new terraform variables have proper descriptions
